### PR TITLE
Fix bug where status_code OK was never read.

### DIFF
--- a/pep381client/__init__.py
+++ b/pep381client/__init__.py
@@ -311,6 +311,7 @@ class Synchronization:
         response = None
         try:
             response = urllib2.urlopen(request)
+            status_code = response.getcode()
         except urllib2.HTTPError, e:
             status_code = e.code
             print  "Error Code: " + str(e.code) + ', when maybe_copy_file ' + e


### PR DESCRIPTION
We are using this client to create our own mirror.
When executing the script the packages where not downloaded, we looked into it.

We found a bug, where the status_code was checked for 200 on line 328, but never read from the response. The status_code is always None at that point.

This commit fixes the bug, and we are able to download the packages (sources).
